### PR TITLE
enable dependabot for GitHub actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"

--- a/doc/MatrixDepot_Demo.ipynb
+++ b/doc/MatrixDepot_Demo.ipynb
@@ -9,10 +9,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 218,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "using MatrixDepot"
@@ -29,131 +27,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 299,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/latex": [
-       "\\subsubsection{Currently loaded Matrices}\n",
-       "\\begin{tabular}\n",
-       "{l | l | l | l | l}\n",
-       "builtin(\\#) &  &  &  &  \\\\\n",
-       "\\hline\n",
-       "1 baart & 13 fiedler & 25 invhilb & 37 parter & 49 shaw \\\\\n",
-       "2 binomial & 14 forsythe & 26 invol & 38 pascal & 50 smallworld \\\\\n",
-       "3 blur & 15 foxgood & 27 kahan & 39 pei & 51 spikes \\\\\n",
-       "4 cauchy & 16 frank & 28 kms & 40 phillips & 52 toeplitz \\\\\n",
-       "5 chebspec & 17 gilbert & 29 lehmer & 41 poisson & 53 tridiag \\\\\n",
-       "6 chow & 18 golub & 30 lotkin & 42 prolate & 54 triw \\\\\n",
-       "7 circul & 19 gravity & 31 magic & 43 randcorr & 55 ursell \\\\\n",
-       "8 clement & 20 grcar & 32 minij & 44 rando & 56 vand \\\\\n",
-       "9 companion & 21 hadamard & 33 moler & 45 randsvd & 57 wathen \\\\\n",
-       "10 deriv2 & 22 hankel & 34 neumann & 46 rohess & 58 wilkinson \\\\\n",
-       "11 dingdong & 23 heat & 35 oscillate & 47 rosser & 59 wing \\\\\n",
-       "12 erdrey & 24 hilb & 36 parallax & 48 sampling &  \\\\\n",
-       "\\end{tabular}\n",
-       "\\begin{tabular}\n",
-       "{l}\n",
-       "user(\\#) \\\\\n",
-       "\\hline\n",
-       "\\end{tabular}\n",
-       "\\begin{tabular}\n",
-       "{l | l | l | l | l | l | l | l | l | l | l | l | l}\n",
-       "Groups &  &  &  &  &  &  &  &  &  &  &  &  \\\\\n",
-       "\\hline\n",
-       "all & local & eigen & illcond & posdef & regprob & symmetric &  &  &  &  &  &  \\\\\n",
-       "builtin & user & graph & inverse & random & sparse & paper1\\_test &  &  &  &  &  &  \\\\\n",
-       "\\end{tabular}\n",
-       "\\begin{tabular}\n",
-       "{l | l}\n",
-       "Suite Sparse & of \\\\\n",
-       "\\hline\n",
-       "2777 & 2893 \\\\\n",
-       "\\end{tabular}\n",
-       "\\begin{tabular}\n",
-       "{l | l}\n",
-       "MatrixMarket & of \\\\\n",
-       "\\hline\n",
-       "488 & 498 \\\\\n",
-       "\\end{tabular}\n"
-      ],
-      "text/markdown": [
-       "### Currently loaded Matrices\n",
-       "\n",
-       "| builtin(#)  |             |              |             |               |\n",
-       "|:----------- |:----------- |:------------ |:----------- |:------------- |\n",
-       "| 1 baart     | 13 fiedler  | 25 invhilb   | 37 parter   | 49 shaw       |\n",
-       "| 2 binomial  | 14 forsythe | 26 invol     | 38 pascal   | 50 smallworld |\n",
-       "| 3 blur      | 15 foxgood  | 27 kahan     | 39 pei      | 51 spikes     |\n",
-       "| 4 cauchy    | 16 frank    | 28 kms       | 40 phillips | 52 toeplitz   |\n",
-       "| 5 chebspec  | 17 gilbert  | 29 lehmer    | 41 poisson  | 53 tridiag    |\n",
-       "| 6 chow      | 18 golub    | 30 lotkin    | 42 prolate  | 54 triw       |\n",
-       "| 7 circul    | 19 gravity  | 31 magic     | 43 randcorr | 55 ursell     |\n",
-       "| 8 clement   | 20 grcar    | 32 minij     | 44 rando    | 56 vand       |\n",
-       "| 9 companion | 21 hadamard | 33 moler     | 45 randsvd  | 57 wathen     |\n",
-       "| 10 deriv2   | 22 hankel   | 34 neumann   | 46 rohess   | 58 wilkinson  |\n",
-       "| 11 dingdong | 23 heat     | 35 oscillate | 47 rosser   | 59 wing       |\n",
-       "| 12 erdrey   | 24 hilb     | 36 parallax  | 48 sampling |               |\n",
-       "\n",
-       "| user(#) |\n",
-       "|:------- |\n",
-       "\n",
-       "| Groups  |       |       |         |        |         |             |     |     |     |     |     |     |\n",
-       "|:------- |:----- |:----- |:------- |:------ |:------- |:----------- |:--- |:--- |:--- |:--- |:--- |:--- |\n",
-       "| all     | local | eigen | illcond | posdef | regprob | symmetric   |     |     |     |     |     |     |\n",
-       "| builtin | user  | graph | inverse | random | sparse  | paper1_test |     |     |     |     |     |     |\n",
-       "\n",
-       "| Suite Sparse | of   |\n",
-       "|:------------ |:---- |\n",
-       "| 2777         | 2893 |\n",
-       "\n",
-       "| MatrixMarket | of  |\n",
-       "|:------------ |:--- |\n",
-       "| 488          | 498 |\n"
-      ],
-      "text/plain": [
-       "\u001b[1m  Currently loaded Matrices\u001b[22m\n",
-       "\u001b[1m  –––––––––––––––––––––––––––\u001b[22m\n",
-       "\n",
-       "  builtin(#)                                                    \n",
-       "  ––––––––––– ––––––––––– –––––––––––– ––––––––––– –––––––––––––\n",
-       "  1 baart     13 fiedler  25 invhilb   37 parter   49 shaw      \n",
-       "  2 binomial  14 forsythe 26 invol     38 pascal   50 smallworld\n",
-       "  3 blur      15 foxgood  27 kahan     39 pei      51 spikes    \n",
-       "  4 cauchy    16 frank    28 kms       40 phillips 52 toeplitz  \n",
-       "  5 chebspec  17 gilbert  29 lehmer    41 poisson  53 tridiag   \n",
-       "  6 chow      18 golub    30 lotkin    42 prolate  54 triw      \n",
-       "  7 circul    19 gravity  31 magic     43 randcorr 55 ursell    \n",
-       "  8 clement   20 grcar    32 minij     44 rando    56 vand      \n",
-       "  9 companion 21 hadamard 33 moler     45 randsvd  57 wathen    \n",
-       "  10 deriv2   22 hankel   34 neumann   46 rohess   58 wilkinson \n",
-       "  11 dingdong 23 heat     35 oscillate 47 rosser   59 wing      \n",
-       "  12 erdrey   24 hilb     36 parallax  48 sampling              \n",
-       "\n",
-       "  user(#)\n",
-       "  –––––––\n",
-       "\n",
-       "  Groups                                                      \n",
-       "  ––––––– ––––– ––––– ––––––– –––––– ––––––– –––––––––––      \n",
-       "  all     local eigen illcond posdef regprob symmetric        \n",
-       "  builtin user  graph inverse random sparse  paper1_test      \n",
-       "\n",
-       "  Suite Sparse of  \n",
-       "  –––––––––––– ––––\n",
-       "  2777         2893\n",
-       "\n",
-       "  MatrixMarket of \n",
-       "  –––––––––––– –––\n",
-       "  488          498"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "mdinfo()"
    ]
@@ -167,143 +43,36 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 220,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "14-element Vector{String}:\n",
-       " \"cauchy\"\n",
-       " \"circul\"\n",
-       " \"hilb\"\n",
-       " \"invhilb\"\n",
-       " \"kms\"\n",
-       " \"lehmer\"\n",
-       " \"minij\"\n",
-       " \"moler\"\n",
-       " \"oscillate\"\n",
-       " \"pascal\"\n",
-       " \"pei\"\n",
-       " \"poisson\"\n",
-       " \"tridiag\"\n",
-       " \"wathen\""
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "mdlist(:symmetric & :posdef)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 221,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/latex": [
-       "\\section{Magic Square Matrix (magic)}\n",
-       "The magic matrix is a matrix with integer entries such that     the row elements, column elements, diagonal elements and     anti-diagonal elements all add up to the same number.\n",
-       "\n",
-       "\\emph{Input options:}\n",
-       "\n",
-       "\\begin{itemize}\n",
-       "\\item [type,] dim: the dimension of the matrix.\n",
-       "\n",
-       "\\end{itemize}\n",
-       "\\emph{Groups:} [\"inverse\"]\n",
-       "\n"
-      ],
-      "text/markdown": [
-       "# Magic Square Matrix (magic)\n",
-       "\n",
-       "The magic matrix is a matrix with integer entries such that     the row elements, column elements, diagonal elements and     anti-diagonal elements all add up to the same number.\n",
-       "\n",
-       "*Input options:*\n",
-       "\n",
-       "  * [type,] dim: the dimension of the matrix.\n",
-       "\n",
-       "*Groups:* [\"inverse\"]\n"
-      ],
-      "text/plain": [
-       "\u001b[1m  Magic Square Matrix (magic)\u001b[22m\n",
-       "\u001b[1m  ≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡≡\u001b[22m\n",
-       "\n",
-       "  The magic matrix is a matrix with integer entries such that the row\n",
-       "  elements, column elements, diagonal elements and anti-diagonal elements all\n",
-       "  add up to the same number.\n",
-       "\n",
-       "  \u001b[4mInput options:\u001b[24m\n",
-       "\n",
-       "    •  [type,] dim: the dimension of the matrix.\n",
-       "\n",
-       "  \u001b[4mGroups:\u001b[24m [\"inverse\"]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "mdinfo(\"magic\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 222,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "5×5 Matrix{Float64}:\n",
-       " 17.0  24.0   1.0   8.0  15.0\n",
-       " 23.0   5.0   7.0  14.0  16.0\n",
-       "  4.0   6.0  13.0  20.0  22.0\n",
-       " 10.0  12.0  19.0  21.0   3.0\n",
-       " 11.0  18.0  25.0   2.0   9.0"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "A = matrixdepot(\"magic\", 5)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 223,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "5×5 Matrix{Float32}:\n",
-       " 17.0  24.0   1.0   8.0  15.0\n",
-       " 23.0   5.0   7.0  14.0  16.0\n",
-       "  4.0   6.0  13.0  20.0  22.0\n",
-       " 10.0  12.0  19.0  21.0   3.0\n",
-       " 11.0  18.0  25.0   2.0   9.0"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "mdopen(\"magic\", Float32, 5).A"
    ]
@@ -317,90 +86,36 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 249,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "1×5 Matrix{Float64}:\n",
-       " 65.0  65.0  65.0  65.0  65.0"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "sum(A, dims=1)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 250,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "5×1 Matrix{Float64}:\n",
-       " 65.0\n",
-       " 65.0\n",
-       " 65.0\n",
-       " 65.0\n",
-       " 65.0"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "sum(A, dims=2)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 226,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "65.0"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "sum(diag(A))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 251,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "65.0"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "p = 5:-1:1\n",
     "sum(diag(A[:,p]))"
@@ -408,133 +123,36 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 254,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "A = [17.0 24.0 1.0 8.0 15.0; 23.0 5.0 7.0 14.0 16.0; 4.0 6.0 13.0 20.0 22.0; 10.0 12.0 19.0 21.0 3.0; 11.0 18.0 25.0 2.0 9.0]\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "5×5 Matrix{Float64}:\n",
-       " 17.0  24.0   1.0   8.0  15.0\n",
-       " 23.0   5.0   7.0  14.0  16.0\n",
-       "  4.0   6.0  13.0  20.0  22.0\n",
-       " 10.0  12.0  19.0  21.0   3.0\n",
-       " 11.0  18.0  25.0   2.0   9.0"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "@show A"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 255,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "12×12 Tridiagonal{Float64, Vector{Float64}}:\n",
-       " 5.5  1.0   ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅ \n",
-       " 1.0  4.5  1.0   ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅ \n",
-       "  ⋅   1.0  3.5  1.0   ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅ \n",
-       "  ⋅    ⋅   1.0  2.5  1.0   ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅ \n",
-       "  ⋅    ⋅    ⋅   1.0  1.5  1.0   ⋅    ⋅    ⋅    ⋅    ⋅    ⋅ \n",
-       "  ⋅    ⋅    ⋅    ⋅   1.0  0.5  1.0   ⋅    ⋅    ⋅    ⋅    ⋅ \n",
-       "  ⋅    ⋅    ⋅    ⋅    ⋅   1.0  0.5  1.0   ⋅    ⋅    ⋅    ⋅ \n",
-       "  ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   1.0  1.5  1.0   ⋅    ⋅    ⋅ \n",
-       "  ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   1.0  2.5  1.0   ⋅    ⋅ \n",
-       "  ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   1.0  3.5  1.0   ⋅ \n",
-       "  ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   1.0  4.5  1.0\n",
-       "  ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅    ⋅   1.0  5.5"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "B = matrixdepot(\"wilkinson\", 12)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 257,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Matrix(B) = [5.5 1.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0; 1.0 4.5 1.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0; 0.0 1.0 3.5 1.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 1.0 2.5 1.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 1.0 1.5 1.0 0.0 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 1.0 0.5 1.0 0.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0 1.0 0.5 1.0 0.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0 0.0 1.0 1.5 1.0 0.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0 0.0 0.0 1.0 2.5 1.0 0.0 0.0; 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 1.0 3.5 1.0 0.0; 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 1.0 4.5 1.0; 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 1.0 5.5]\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "12×12 Matrix{Float64}:\n",
-       " 5.5  1.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0\n",
-       " 1.0  4.5  1.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0\n",
-       " 0.0  1.0  3.5  1.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0\n",
-       " 0.0  0.0  1.0  2.5  1.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0\n",
-       " 0.0  0.0  0.0  1.0  1.5  1.0  0.0  0.0  0.0  0.0  0.0  0.0\n",
-       " 0.0  0.0  0.0  0.0  1.0  0.5  1.0  0.0  0.0  0.0  0.0  0.0\n",
-       " 0.0  0.0  0.0  0.0  0.0  1.0  0.5  1.0  0.0  0.0  0.0  0.0\n",
-       " 0.0  0.0  0.0  0.0  0.0  0.0  1.0  1.5  1.0  0.0  0.0  0.0\n",
-       " 0.0  0.0  0.0  0.0  0.0  0.0  0.0  1.0  2.5  1.0  0.0  0.0\n",
-       " 0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  1.0  3.5  1.0  0.0\n",
-       " 0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  1.0  4.5  1.0\n",
-       " 0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0  1.0  5.5"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "@show Matrix(B)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 231,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "6×6 Matrix{Bool}:\n",
-       " 0  1  1  0  1  1\n",
-       " 1  0  0  1  1  0\n",
-       " 1  0  0  1  0  1\n",
-       " 1  1  0  0  1  1\n",
-       " 1  0  0  0  0  0\n",
-       " 0  1  0  0  0  0"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "matrixdepot(\"rando\", Bool, 6)"
    ]
@@ -548,26 +166,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 259,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "5×5 Matrix{BigFloat}:\n",
-       " 1.0       0.5       0.333333  0.25      0.2\n",
-       " 0.5       0.333333  0.25      0.2       0.166667\n",
-       " 0.333333  0.25      0.2       0.166667  0.142857\n",
-       " 0.25      0.2       0.166667  0.142857  0.125\n",
-       " 0.2       0.166667  0.142857  0.125     0.111111"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "setprecision(200)\n",
     "H = matrixdepot(\"hilb\", BigFloat, 5)"
@@ -599,9 +200,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "matrixdepot(\"Collection/somematrix\")"
@@ -617,82 +216,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 287,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "1138×1138 Symmetric{Float64, SparseMatrixCSC{Float64, Int64}}:\n",
-       " 1474.78      0.0       0.0     …   0.0       0.0         0.0    0.0\n",
-       "    0.0       9.13665   0.0         0.0       0.0         0.0    0.0\n",
-       "    0.0       0.0      69.6147      0.0       0.0         0.0    0.0\n",
-       "    0.0       0.0       0.0         0.0       0.0         0.0    0.0\n",
-       "   -9.01713   0.0       0.0         0.0       0.0         0.0    0.0\n",
-       "    0.0       0.0       0.0     …   0.0       0.0         0.0    0.0\n",
-       "    0.0       0.0       0.0         0.0       0.0         0.0    0.0\n",
-       "    0.0       0.0       0.0         0.0       0.0         0.0    0.0\n",
-       "    0.0       0.0       0.0         0.0       0.0         0.0    0.0\n",
-       "    0.0      -3.40599   0.0         0.0       0.0         0.0    0.0\n",
-       "    ⋮                           ⋱             ⋮                \n",
-       "    0.0       0.0       0.0         0.0       0.0         0.0    0.0\n",
-       "    0.0       0.0       0.0     …   0.0     -24.3902      0.0    0.0\n",
-       "    0.0       0.0       0.0         0.0       0.0         0.0    0.0\n",
-       "    0.0       0.0       0.0         0.0       0.0         0.0    0.0\n",
-       "    0.0       0.0       0.0         0.0       0.0         0.0    0.0\n",
-       "    0.0       0.0       0.0        26.5639    0.0         0.0    0.0\n",
-       "    0.0       0.0       0.0     …   0.0      46.1767      0.0    0.0\n",
-       "    0.0       0.0       0.0         0.0       0.0     10000.0    0.0\n",
-       "    0.0       0.0       0.0         0.0       0.0         0.0  117.647"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "A = matrixdepot(\"*/1138_bus\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 289,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "1138×1138 SparseMatrixCSC{Float64, Int64} with 4054 stored entries:\n",
-       "⣿⢟⡀⢸⠀⡀⠀⠀⠀⠀⠀⠀⠀⠀⢒⠀⠈⣀⠀⠜⠀⠀⠀⠀⠠⠁⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀\n",
-       "⣀⣈⠻⣦⡾⡀⠐⠂⠣⣤⢤⠤⠀⠀⢘⠸⢄⠀⠀⠀⠀⠀⠀⠀⢀⣀⠀⠀⠂⠀⠀⠀⠂⠀⠀⠀⠐⠒⠁⠀\n",
-       "⠀⠠⠚⠫⠻⣦⣆⣐⡀⠄⠀⠌⠨⠁⠀⠀⠀⠈⠀⠂⠀⠀⠀⠀⠩⠐⡔⠀⠠⠄⠠⠀⠀⠀⠀⠉⠀⠀⠀⠀\n",
-       "⠀⠀⠰⠀⢈⢹⣿⣿⡂⠀⠀⠀⠀⠀⠀⠀⠀⢀⠀⠀⠀⠀⠀⠀⠀⠀⡁⠀⠀⠀⠀⠀⠀⠀⠀⢀⠀⠀⠀⠀\n",
-       "⠀⠀⠉⣦⠀⠌⠈⠈⣿⣿⣿⡶⠈⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠈⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀\n",
-       "⠀⠀⠀⡗⡀⠄⠀⠀⢻⡿⢻⣶⡀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠢⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀\n",
-       "⠀⠀⠀⠀⠆⠂⠀⠀⠂⠀⠀⠈⢿⣷⡇⠀⢐⠀⠀⠀⠀⠀⠀⠀⠂⡂⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀\n",
-       "⠘⠐⣒⡐⠀⠀⠀⠀⠀⠀⠀⠀⠉⠉⠻⣦⣞⢡⣦⠢⠀⠀⠀⠀⠐⠋⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀\n",
-       "⠂⢠⠀⠑⡀⠀⠀⢀⠀⠀⠀⠀⠐⠐⠞⣙⠱⣦⣄⡋⡀⣀⡀⠀⠰⠲⠀⡀⢀⠀⠀⢀⣀⠈⠀⠀⠀⠀⠀⠀\n",
-       "⣀⠄⠀⠀⠠⠀⠀⠀⠀⠀⠀⠀⠀⠀⠨⡛⡤⠹⡿⣯⡇⢀⠐⠒⠠⠀⠈⣛⠓⠀⠐⢰⠒⠛⣉⠀⠐⠒⠀⠂\n",
-       "⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢨⠉⢉⢻⣶⣄⠂⠀⠀⠀⠍⠁⠀⠀⠁⠁⠀⠀⠀⠀⡆⠥⡀\n",
-       "⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠈⢰⠀⠠⠙⢻⣶⡀⠀⠀⠈⠀⠀⠀⠀⠀⠀⠀⠀⣲⡂⠁⡄\n",
-       "⠄⠂⠀⢰⢃⠂⠀⠀⠂⠀⠈⠂⠨⠠⡴⠀⢰⡂⠀⠂⠀⠀⠀⠈⢻⣶⣀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀\n",
-       "⠀⠀⠀⠀⠐⠉⠁⠈⠀⠀⠀⠀⠀⠀⠀⠀⠀⠠⣦⢠⡄⠄⡀⠀⠀⠘⠻⣦⣔⠀⠀⠀⠀⡄⠀⠀⠀⠀⣀⣄\n",
-       "⠀⠀⠈⠀⠀⠆⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠐⠙⠀⠁⠀⠀⠀⠀⠀⠐⠙⠻⣦⣼⠛⠛⠀⠀⠀⠀⠀⠀⠉\n",
-       "⠀⠀⠀⠀⠀⠂⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⢐⣀⠄⠀⠀⠀⠀⠀⠀⠀⣶⠛⢻⣶⣶⣄⢀⠀⠀⠀⠀⡆\n",
-       "⠀⠀⠈⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⡀⠘⣼⠀⠁⠀⠀⠀⠀⠀⠀⠤⠛⠀⠘⢿⠻⣦⡌⠀⠀⠀⠀⠙\n",
-       "⠀⠀⠀⠀⡄⠀⠀⢀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠃⠘⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠐⠂⠉⠛⣤⡄⠀⠀⠀\n",
-       "⠀⠀⢰⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢰⠀⠠⠤⠸⠺⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠉⠛⣤⡤⡀\n",
-       "⠀⠀⠁⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠠⠀⠁⠣⠁⠤⠀⠀⠀⢼⡄⠀⠠⠤⣄⠀⠀⠀⠀⠫⠿⣧"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "@show sparse(A)"
    ]
@@ -706,41 +241,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 290,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "47-element Vector{String}:\n",
-       " \"HB/abb313\"\n",
-       " \"HB/ash331\"\n",
-       " \"HB/ash608\"\n",
-       " \"HB/ash958\"\n",
-       " \"HB/illc1850\"\n",
-       " \"HB/well1850\"\n",
-       " \"Harwell-Boeing/lsq/illc1850\"\n",
-       " \"Harwell-Boeing/lsq/well1850\"\n",
-       " \"Harwell-Boeing/smtape/abb313\"\n",
-       " \"Harwell-Boeing/smtape/ash331\"\n",
-       " ⋮\n",
-       " \"JGD_Relat/relat5\"\n",
-       " \"JGD_Relat/relat6\"\n",
-       " \"JGD_SL6/D_5\"\n",
-       " \"JGD_SL6/D_6\"\n",
-       " \"JGD_Taha/abtaha1\"\n",
-       " \"NYPA/Maragal_2\"\n",
-       " \"Pajek/WorldCities\"\n",
-       " \"Priebel/130bit\"\n",
-       " \"Priebel/145bit\""
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "mdlist(isloaded & @pred(n < 1000 & m > 200) & !issymmetric) "
    ]
@@ -754,10 +257,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 291,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "setgroup!(:paper1_test, [\"HB/1138_bus\", \"hilb\", \"cauchy\", \"pei\"])"
@@ -765,59 +266,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 292,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "4-element Vector{String}:\n",
-       " \"HB/1138_bus\"\n",
-       " \"cauchy\"\n",
-       " \"hilb\"\n",
-       " \"pei\""
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "mdlist(:paper1_test)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 294,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/latex": [
-       "\\begin{tabular}\n",
-       "{l | l | l | l}\n",
-       "list(4) &  &  &  \\\\\n",
-       "\\hline\n",
-       "HB/1138\\_bus & cauchy & hilb & pei \\\\\n",
-       "\\end{tabular}\n"
-      ],
-      "text/markdown": [
-       "| list(4)     |        |      |     |\n",
-       "|:----------- |:------ |:---- |:--- |\n",
-       "| HB/1138_bus | cauchy | hilb | pei |\n"
-      ],
-      "text/plain": [
-       "  list(4)                    \n",
-       "  ––––––––––– –––––– –––– –––\n",
-       "  HB/1138_bus cauchy hilb pei"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "listnames(:paper1_test)"
    ]

--- a/doc/juliadoc.ipynb
+++ b/doc/juliadoc.ipynb
@@ -1,8 +1,7 @@
 {
  "metadata": {
   "language": "Julia",
-  "name": "",
-  "signature": "sha256:4526fbc78f0271590c8440dc825aecfd5f737f9e9ce1cca29f8d7a3b4c1db99a"
+  "name": ""
  },
  "nbformat": 3,
  "nbformat_minor": 0,
@@ -66,7 +65,7 @@
      "language": "python",
      "metadata": {},
      "outputs": [],
-     "prompt_number": 1
+     "prompt_number": null
     },
     {
      "cell_type": "markdown",
@@ -83,23 +82,8 @@
      ],
      "language": "python",
      "metadata": {},
-     "outputs": [
-      {
-       "output_type": "stream",
-       "stream": "stderr",
-       "text": [
-        "INFO: Loading help data...\n"
-       ]
-      },
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "matrixdepot (generic function with 17 methods)\n"
-       ]
-      }
-     ],
-     "prompt_number": 2
+     "outputs": [],
+     "prompt_number": null
     },
     {
      "cell_type": "markdown",
@@ -162,50 +146,8 @@
      ],
      "language": "python",
      "metadata": {},
-     "outputs": [
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "\n",
-        "          | symmetric |  inverse  | ill-cond  |  pos-def  |  eigen    |"
-       ]
-      },
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "\n",
-        "      vand|           |     *     |     *     |           |           |\n",
-        "     frank|           |           |     *     |           |     *     |\n",
-        "     minij|     *     |     *     |           |     *     |     *     |\n",
-        "   clement|     *     |     *     |           |           |     *     |\n",
-        "   tridiag|     *     |     *     |     *     |     *     |     *     |\n",
-        "    circul|     *     |           |           |     *     |     *     |\n",
-        "  dingdong|     *     |           |           |           |     *     |\n",
-        "  hadamard|           |     *     |           |           |     *     |\n",
-        "     moler|     *     |     *     |     *     |     *     |           |\n",
-        "     invol|           |     *     |     *     |           |     *     |\n",
-        "   fiedler|     *     |     *     |           |           |     *     |\n",
-        "  binomial|           |           |           |           |           |\n",
-        "    lehmer|     *     |     *     |           |     *     |           |\n",
-        "   invhilb|     *     |     *     |     *     |     *     |           |\n",
-        "    lotkin|           |     *     |     *     |           |     *     |\n",
-        "      triw|           |     *     |     *     |           |           |\n",
-        "     magic|           |     *     |           |           |           |\n",
-        "     kahan|           |     *     |     *     |           |           |\n",
-        "    pascal|     *     |     *     |     *     |     *     |     *     |\n",
-        "  chebspec|           |           |           |           |     *     |\n",
-        "      hilb|     *     |     *     |     *     |     *     |           |\n",
-        "    cauchy|     *     |     *     |     *     |     *     |           |\n",
-        "       pei|     *     |     *     |     *     |     *     |           |\n",
-        "    parter|           |           |           |           |     *     |\n",
-        "  forsythe|           |     *     |     *     |           |     *     |\n",
-        "     grcar|           |           |           |           |     *     |\n"
-       ]
-      }
-     ],
-     "prompt_number": 3
+     "outputs": [],
+     "prompt_number": null
     },
     {
      "cell_type": "markdown",
@@ -239,21 +181,8 @@
      ],
      "language": "python",
      "metadata": {},
-     "outputs": [
-      {
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 4,
-       "text": [
-        "4x4 Array{Float64,2}:\n",
-        " 1.0       0.5       0.333333  0.25    \n",
-        " 0.5       0.333333  0.25      0.2     \n",
-        " 0.333333  0.25      0.2       0.166667\n",
-        " 0.25      0.2       0.166667  0.142857"
-       ]
-      }
-     ],
-     "prompt_number": 4
+     "outputs": [],
+     "prompt_number": null
     },
     {
      "cell_type": "markdown",
@@ -270,22 +199,8 @@
      ],
      "language": "python",
      "metadata": {},
-     "outputs": [
-      {
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 5,
-       "text": [
-        "5x5 Array{Float64,2}:\n",
-        " 1.0  2.0  3.0  4.0  5.0\n",
-        " 5.0  1.0  2.0  3.0  4.0\n",
-        " 4.0  5.0  1.0  2.0  3.0\n",
-        " 3.0  4.0  5.0  1.0  2.0\n",
-        " 2.0  3.0  4.0  5.0  1.0"
-       ]
-      }
-     ],
-     "prompt_number": 5
+     "outputs": [],
+     "prompt_number": null
     },
     {
      "cell_type": "markdown",
@@ -302,24 +217,8 @@
      ],
      "language": "python",
      "metadata": {},
-     "outputs": [
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "Hilbert matrix: \n",
-        "             \n",
-        " Input options: \n",
-        "             \n",
-        " (type), dim: the dimension of the matrix\n",
-        "             \n",
-        " (type), row_dim, col_dim: the row and column dimension \n",
-        "             \n",
-        " ['inverse', 'ill-cond', 'symmetric', 'pos-def']\n"
-       ]
-      }
-     ],
-     "prompt_number": 6
+     "outputs": [],
+     "prompt_number": null
     },
     {
      "cell_type": "code",
@@ -329,22 +228,8 @@
      ],
      "language": "python",
      "metadata": {},
-     "outputs": [
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "Hadamard matrix: \n",
-        "             \n",
-        " Input options: \n",
-        "             \n",
-        " (type), dim: the dimension of the matrix, n is a power of 2 \n",
-        "             \n",
-        " ['inverse', 'orthogonal', 'eigen']\n"
-       ]
-      }
-     ],
-     "prompt_number": 7
+     "outputs": [],
+     "prompt_number": null
     },
     {
      "cell_type": "markdown",
@@ -362,21 +247,8 @@
      ],
      "language": "python",
      "metadata": {},
-     "outputs": [
-      {
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 8,
-       "text": [
-        "4x6 Array{Float64,2}:\n",
-        " 1.0       0.5       0.333333  0.25      0.2       0.166667\n",
-        " 0.5       0.333333  0.25      0.2       0.166667  0.142857\n",
-        " 0.333333  0.25      0.2       0.166667  0.142857  0.125   \n",
-        " 0.25      0.2       0.166667  0.142857  0.125     0.111111"
-       ]
-      }
-     ],
-     "prompt_number": 8
+     "outputs": [],
+     "prompt_number": null
     },
     {
      "cell_type": "markdown",
@@ -393,22 +265,8 @@
      ],
      "language": "python",
      "metadata": {},
-     "outputs": [
-      {
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 9,
-       "text": [
-        "5x3 Array{Float16,2}:\n",
-        " 1.0      0.5      0.33325\n",
-        " 0.5      0.33325  0.25   \n",
-        " 0.33325  0.25     0.19995\n",
-        " 0.25     0.19995  0.16663\n",
-        " 0.19995  0.16663  0.14282"
-       ]
-      }
-     ],
-     "prompt_number": 9
+     "outputs": [],
+     "prompt_number": null
     },
     {
      "cell_type": "markdown",
@@ -426,29 +284,8 @@
      ],
      "language": "python",
      "metadata": {},
-     "outputs": [
-      {
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 8,
-       "text": [
-        "12-element Array{ASCIIString,1}:\n",
-        " \"hilb\"    \n",
-        " \"cauchy\"  \n",
-        " \"circul\"  \n",
-        " \"dingdong\"\n",
-        " \"invhilb\" \n",
-        " \"moler\"   \n",
-        " \"pascal\"  \n",
-        " \"pei\"     \n",
-        " \"clement\" \n",
-        " \"fiedler\" \n",
-        " \"minij\"   \n",
-        " \"tridiag\" "
-       ]
-      }
-     ],
-     "prompt_number": 8
+     "outputs": [],
+     "prompt_number": null
     },
     {
      "cell_type": "code",
@@ -458,24 +295,8 @@
      ],
      "language": "python",
      "metadata": {},
-     "outputs": [
-      {
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 11,
-       "text": [
-        "7-element Array{ASCIIString,1}:\n",
-        " \"hilb\"   \n",
-        " \"cauchy\" \n",
-        " \"invhilb\"\n",
-        " \"moler\"  \n",
-        " \"pascal\" \n",
-        " \"pei\"    \n",
-        " \"tridiag\""
-       ]
-      }
-     ],
-     "prompt_number": 11
+     "outputs": [],
+     "prompt_number": null
     },
     {
      "cell_type": "code",
@@ -485,24 +306,8 @@
      ],
      "language": "python",
      "metadata": {},
-     "outputs": [
-      {
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 10,
-       "text": [
-        "7-element Array{ASCIIString,1}:\n",
-        " \"hilb\"   \n",
-        " \"cauchy\" \n",
-        " \"invhilb\"\n",
-        " \"moler\"  \n",
-        " \"pascal\" \n",
-        " \"pei\"    \n",
-        " \"tridiag\""
-       ]
-      }
-     ],
-     "prompt_number": 10
+     "outputs": [],
+     "prompt_number": null
     },
     {
      "cell_type": "markdown",
@@ -527,35 +332,8 @@
      ],
      "language": "python",
      "metadata": {},
-     "outputs": [
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "Identity matrix x hilb matrix"
-       ]
-      },
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        " x cauchy matrix x invhilb matrix x moler matrix x pascal matrix x pei matrix x tridiag matrix =\n"
-       ]
-      },
-      {
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 15,
-       "text": [
-        "4x4 Array{Float64,2}:\n",
-        " 153.12    -11.919    -15.4345   296.937\n",
-        " 109.896    -8.91857  -11.5976   214.433\n",
-        "  86.7524   -7.15714   -9.32857  169.702\n",
-        "  71.9139   -5.98707   -7.81497  140.876"
-       ]
-      }
-     ],
-     "prompt_number": 15
+     "outputs": [],
+     "prompt_number": null
     },
     {
      "cell_type": "markdown",
@@ -579,35 +357,8 @@
      ],
      "language": "python",
      "metadata": {},
-     "outputs": [
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "Identity matrix x hilb matrix"
-       ]
-      },
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        " x cauchy matrix x invhilb matrix x moler matrix x pascal matrix x pei matrix x tridiag matrix =\n"
-       ]
-      },
-      {
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 16,
-       "text": [
-        "4x4 Array{Float64,2}:\n",
-        " 153.12    -11.919    -15.4345   296.937\n",
-        " 109.896    -8.91857  -11.5976   214.433\n",
-        "  86.7524   -7.15714   -9.32857  169.702\n",
-        "  71.9139   -5.98707   -7.81497  140.876"
-       ]
-      }
-     ],
-     "prompt_number": 16
+     "outputs": [],
+     "prompt_number": null
     },
     {
      "cell_type": "markdown",
@@ -631,27 +382,8 @@
      ],
      "language": "python",
      "metadata": {},
-     "outputs": [
-      {
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 2,
-       "text": [
-        "10-element Array{ASCIIString,1}:\n",
-        " \"hilb\"   \n",
-        " \"cauchy\" \n",
-        " \"circul\" \n",
-        " \"invhilb\"\n",
-        " \"moler\"  \n",
-        " \"pascal\" \n",
-        " \"pei\"    \n",
-        " \"minij\"  \n",
-        " \"tridiag\"\n",
-        " \"lehmer\" "
-       ]
-      }
-     ],
-     "prompt_number": 2
+     "outputs": [],
+     "prompt_number": null
     },
     {
      "cell_type": "code",
@@ -661,20 +393,8 @@
      ],
      "language": "python",
      "metadata": {},
-     "outputs": [
-      {
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 5,
-       "text": [
-        "3-element Array{ASCIIString,1}:\n",
-        " \"lehmer\"\n",
-        " \"cauchy\"\n",
-        " \"hilb\"  "
-       ]
-      }
-     ],
-     "prompt_number": 5
+     "outputs": [],
+     "prompt_number": null
     },
     {
      "cell_type": "markdown",
@@ -696,25 +416,8 @@
      ],
      "language": "python",
      "metadata": {},
-     "outputs": [
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "1-norm error for lehmer matrix is 1"
-       ]
-      },
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        ".1102230246251565e-16\n",
-        "1-norm error for cauchy matrix is 5.551115123125783e-17\n",
-        "1-norm error for hilb matrix is 2.7755575615628914e-17\n"
-       ]
-      }
-     ],
-     "prompt_number": 8
+     "outputs": [],
+     "prompt_number": null
     },
     {
      "cell_type": "markdown",
@@ -731,17 +434,8 @@
      ],
      "language": "python",
      "metadata": {},
-     "outputs": [
-      {
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 2,
-       "text": [
-        "87"
-       ]
-      }
-     ],
-     "prompt_number": 2
+     "outputs": [],
+     "prompt_number": null
     },
     {
      "cell_type": "code",
@@ -751,17 +445,8 @@
      ],
      "language": "python",
      "metadata": {},
-     "outputs": [
-      {
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 4,
-       "text": [
-        "195"
-       ]
-      }
-     ],
-     "prompt_number": 4
+     "outputs": [],
+     "prompt_number": null
     },
     {
      "cell_type": "markdown",
@@ -778,56 +463,8 @@
      ],
      "language": "python",
      "metadata": {},
-     "outputs": [
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "\n",
-        "          | symmetric |  inverse  | ill-cond  |  pos-def  |  eigen    |"
-       ]
-      },
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "\n",
-        "      vand|           |     *     |     *     |           |           |\n",
-        "     frank|           |           |     *     |           |     *     |\n",
-        "     minij|     *     |     *     |           |     *     |     *     |\n",
-        "   clement|     *     |     *     |           |           |     *     |\n",
-        "   tridiag|     *     |     *     |     *     |     *     |     *     |\n",
-        "    circul|     *     |           |           |     *     |     *     |\n",
-        "  dingdong|     *     |           |           |           |     *     |\n",
-        "  hadamard|           |     *     |           |           |     *     |\n",
-        "     moler|     *     |     *     |     *     |     *     |           |\n",
-        "     invol|           |     *     |     *     |           |     *     |\n",
-        "   fiedler|     *     |     *     |           |           |     *     |\n",
-        "  binomial|           |           |           |           |           |\n",
-        "    lehmer|     *     |     *     |           |     *     |           |\n",
-        "   invhilb|     *     |     *     |     *     |     *     |           |\n",
-        "    lotkin|           |     *     |     *     |           |     *     |\n",
-        "      triw|           |     *     |     *     |           |           |\n",
-        "     magic|           |     *     |           |           |           |\n",
-        "     kahan|           |     *     |     *     |           |           |\n",
-        "    pascal|     *     |     *     |     *     |     *     |     *     |\n",
-        "  chebspec|           |           |           |           |     *     |\n",
-        "      hilb|     *     |     *     |     *     |     *     |           |\n",
-        "    cauchy|     *     |     *     |     *     |     *     |           |\n",
-        "       pei|     *     |     *     |     *     |     *     |           |\n",
-        "  forsythe|           |     *     |     *     |           |     *     |\n",
-        "     grcar|           |           |           |           |     *     |\n",
-        "\n",
-        "New Properties:\n",
-        "\n",
-        "spd = [ hilb, cauchy, circul, invhilb, moler, pascal, pei, minij, tridiag, lehmer, ] \n",
-        "\n",
-        "myfav = [ lehmer, cauchy, hilb, ] \n",
-        "\n"
-       ]
-      }
-     ],
-     "prompt_number": 2
+     "outputs": [],
+     "prompt_number": null
     },
     {
      "cell_type": "markdown",
@@ -844,20 +481,8 @@
      ],
      "language": "python",
      "metadata": {},
-     "outputs": [
-      {
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 3,
-       "text": [
-        "3-element Array{ASCIIString,1}:\n",
-        " \"lehmer\"\n",
-        " \"cauchy\"\n",
-        " \"hilb\"  "
-       ]
-      }
-     ],
-     "prompt_number": 3
+     "outputs": [],
+     "prompt_number": null
     },
     {
      "cell_type": "markdown",
@@ -874,17 +499,8 @@
      ],
      "language": "python",
      "metadata": {},
-     "outputs": [
-      {
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 4,
-       "text": [
-        "153"
-       ]
-      }
-     ],
-     "prompt_number": 4
+     "outputs": [],
+     "prompt_number": null
     },
     {
      "cell_type": "code",
@@ -894,54 +510,8 @@
      ],
      "language": "python",
      "metadata": {},
-     "outputs": [
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "\n",
-        "          | symmetric |  inverse  | ill-cond  |  pos-def  |  eigen    |"
-       ]
-      },
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "\n",
-        "      vand|           |     *     |     *     |           |           |\n",
-        "     frank|           |           |     *     |           |     *     |\n",
-        "     minij|     *     |     *     |           |     *     |     *     |\n",
-        "   clement|     *     |     *     |           |           |     *     |\n",
-        "   tridiag|     *     |     *     |     *     |     *     |     *     |\n",
-        "    circul|     *     |           |           |     *     |     *     |\n",
-        "  dingdong|     *     |           |           |           |     *     |\n",
-        "  hadamard|           |     *     |           |           |     *     |\n",
-        "     moler|     *     |     *     |     *     |     *     |           |\n",
-        "     invol|           |     *     |     *     |           |     *     |\n",
-        "   fiedler|     *     |     *     |           |           |     *     |\n",
-        "  binomial|           |           |           |           |           |\n",
-        "    lehmer|     *     |     *     |           |     *     |           |\n",
-        "   invhilb|     *     |     *     |     *     |     *     |           |\n",
-        "    lotkin|           |     *     |     *     |           |     *     |\n",
-        "      triw|           |     *     |     *     |           |           |\n",
-        "     magic|           |     *     |           |           |           |\n",
-        "     kahan|           |     *     |     *     |           |           |\n",
-        "    pascal|     *     |     *     |     *     |     *     |     *     |\n",
-        "  chebspec|           |           |           |           |     *     |\n",
-        "      hilb|     *     |     *     |     *     |     *     |           |\n",
-        "    cauchy|     *     |     *     |     *     |     *     |           |\n",
-        "       pei|     *     |     *     |     *     |     *     |           |\n",
-        "  forsythe|           |     *     |     *     |           |     *     |\n",
-        "     grcar|           |           |           |           |     *     |\n",
-        "\n",
-        "New Properties:\n",
-        "\n",
-        "spd = [ hilb, cauchy, circul, invhilb, moler, pascal, pei, minij, tridiag, lehmer, ] \n",
-        "\n"
-       ]
-      }
-     ],
-     "prompt_number": 3
+     "outputs": [],
+     "prompt_number": null
     },
     {
      "cell_type": "markdown",
@@ -965,22 +535,8 @@
      ],
      "language": "python",
      "metadata": {},
-     "outputs": [
-      {
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 16,
-       "text": [
-        "5x5 Array{Int64,2}:\n",
-        " 17  24   1   8  15\n",
-        " 23   5   7  14  16\n",
-        "  4   6  13  20  22\n",
-        " 10  12  19  21   3\n",
-        " 11  18  25   2   9"
-       ]
-      }
-     ],
-     "prompt_number": 16
+     "outputs": [],
+     "prompt_number": null
     },
     {
      "cell_type": "code",
@@ -990,18 +546,8 @@
      ],
      "language": "python",
      "metadata": {},
-     "outputs": [
-      {
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 17,
-       "text": [
-        "1x5 Array{Int64,2}:\n",
-        " 65  65  65  65  65"
-       ]
-      }
-     ],
-     "prompt_number": 17
+     "outputs": [],
+     "prompt_number": null
     },
     {
      "cell_type": "code",
@@ -1011,22 +557,8 @@
      ],
      "language": "python",
      "metadata": {},
-     "outputs": [
-      {
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 18,
-       "text": [
-        "5x1 Array{Int64,2}:\n",
-        " 65\n",
-        " 65\n",
-        " 65\n",
-        " 65\n",
-        " 65"
-       ]
-      }
-     ],
-     "prompt_number": 18
+     "outputs": [],
+     "prompt_number": null
     },
     {
      "cell_type": "code",
@@ -1036,17 +568,8 @@
      ],
      "language": "python",
      "metadata": {},
-     "outputs": [
-      {
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 19,
-       "text": [
-        "65"
-       ]
-      }
-     ],
-     "prompt_number": 19
+     "outputs": [],
+     "prompt_number": null
     },
     {
      "cell_type": "code",
@@ -1057,17 +580,8 @@
      ],
      "language": "python",
      "metadata": {},
-     "outputs": [
-      {
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 20,
-       "text": [
-        "65"
-       ]
-      }
-     ],
-     "prompt_number": 20
+     "outputs": [],
+     "prompt_number": null
     },
     {
      "cell_type": "markdown",
@@ -1084,23 +598,8 @@
      ],
      "language": "python",
      "metadata": {},
-     "outputs": [
-      {
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 21,
-       "text": [
-        "6x6 Array{Int64,2}:\n",
-        " 1  1   1   1    1    1\n",
-        " 1  2   3   4    5    6\n",
-        " 1  3   6  10   15   21\n",
-        " 1  4  10  20   35   56\n",
-        " 1  5  15  35   70  126\n",
-        " 1  6  21  56  126  252"
-       ]
-      }
-     ],
-     "prompt_number": 21
+     "outputs": [],
+     "prompt_number": null
     },
     {
      "cell_type": "markdown",
@@ -1117,23 +616,8 @@
      ],
      "language": "python",
      "metadata": {},
-     "outputs": [
-      {
-       "metadata": {},
-       "output_type": "pyout",
-       "prompt_number": 22,
-       "text": [
-        "6x6 Array{Float64,2}:\n",
-        " 1.0  1.0  1.0  1.0  1.0   1.0\n",
-        " 0.0  1.0  2.0  3.0  4.0   5.0\n",
-        " 0.0  0.0  1.0  3.0  6.0  10.0\n",
-        " 0.0  0.0  0.0  1.0  4.0  10.0\n",
-        " 0.0  0.0  0.0  0.0  1.0   5.0\n",
-        " 0.0  0.0  0.0  0.0  0.0   1.0"
-       ]
-      }
-     ],
-     "prompt_number": 22
+     "outputs": [],
+     "prompt_number": null
     }
    ],
    "metadata": {}


### PR DESCRIPTION
This allows to get updates for GitHub actions automatically. I have used this for my own packages, the [Trixi.jl framework](https://github.com/trixi-framework), and the [SciML organization](https://github.com/SciML). After merging this, you could also enable other Dependabot actions in 'Settings -> Code security and analysis -> Dependabot alerts' and '... -> Dependabot security updates'.

See https://github.com/SciML/MuladdMacro.jl/pull/37