### PR TITLE
add group "illcond" to doc of oscillate

### DIFF
--- a/src/regu.jl
+++ b/src/regu.jl
@@ -19,7 +19,7 @@ A matrix `A` is called oscillating if `A` is totally
 
 + [type,] dim: `mode = 1`.
 
-*Groups:* ['symmetric','posdef', 'random', 'eigen']
+*Groups:* ['symmetric', 'illcond', 'posdef', 'random', 'eigen']
 
 *References:*
 


### PR DESCRIPTION
In data.jl, oscillate is in the illcond group: https://github.com/JuliaLinearAlgebra/MatrixDepot.jl/blob/7bf98d10034609e346ead35c7c2c21b1c9644898/src/data.jl#L64-L68